### PR TITLE
Db seeding update

### DIFF
--- a/db/generate_data.js
+++ b/db/generate_data.js
@@ -7,6 +7,7 @@ const moment = require('moment');
 
 const SONG_MAX_COUNT = USER_MAX_COUNT = 10000000; // 10 million
 const ALBUM_MAX_COUNT = ARTIST_MAX_COUNT = 1000000; // 1 million
+const COMMENT_MAX_COUNT = 70000000; // 70 million
 
 function generateArtistData() {
   var start = Date.now(); // to calculate time taken
@@ -156,26 +157,27 @@ function generateSongData() {
     });
 }
 
+// to get songId for comment
+function getRndBias(min, max, bias, influence) {
+  var rnd = Math.random() * (max - min) + min; // random in range
+  var mix = Math.random() * influence; // random mixer
+  return Math.round(rnd * (1 - mix) + bias * mix); // mix full range and bias
+}
+
 function generateCommentData() {
   var start = Date.now(); // to calculate time taken
   var readStream = new Readable();
   var i = 1;
-  var commentId = 1;
   readStream._read = () => {
-    if (i <= SONG_MAX_COUNT) {
-      var commentCount = faker.random.number({min: 5, max: 50}) // generate 5-50 comments per song
-      var records = [];
-      for (let j = 0; j < commentCount; j++) {
-        var record = [];
-        record.push(commentId++); // commentId
-        record.push(i); // songId
-        record.push(faker.random.number({min: 1, max: USER_MAX_COUNT})); // userId
-        record.push(faker.lorem.words(faker.random.number({min: 1, max: 10}))); // comment
-        record.push(faker.random.number(300)); // secondInSong
-        record.push(moment(faker.date.past()).format()); // datePosted, random date in the past year
-        records.push(record.join('|'));
-      }
-      if (records.length) readStream.push(records.join('\n') + '\n');
+    if (i <= COMMENT_MAX_COUNT) {
+      var record = [];
+      record.push(i); // commentId
+      record.push(getRndBias(1, SONG_MAX_COUNT, SONG_MAX_COUNT * 0.8, 0.95)); // songId
+      record.push(faker.random.number({min: 1, max: USER_MAX_COUNT})); // userId
+      record.push(faker.lorem.words(faker.random.number({min: 1, max: 10}))); // comment
+      record.push(faker.random.number(300)); // secondInSong
+      record.push(moment(faker.date.past()).format()); // datePosted, random date in the past year
+      readStream.push(record.join('|') + '\n');
       i++;
     } else {
       readStream.push(null); // close read stream

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3,12 +3,12 @@ CREATE DATABASE aircloudy;
 \c aircloudy;
 
 CREATE TABLE artists (
-  artist_id integer PRIMARY KEY,
+  artist_id integer NOT NULL,
   artist_name text NOT NULL
 );
 
 CREATE TABLE albums (
-  album_id integer PRIMARY KEY,
+  album_id integer NOT NULL,
   album_name text NOT NULL,
   album_release_date date NOT NULL,
   album_art_url text,
@@ -17,9 +17,9 @@ CREATE TABLE albums (
 );
 
 CREATE TABLE songs (
-  song_id integer PRIMARY KEY,
-  artist_id integer NOT NULL REFERENCES artists ON DELETE RESTRICT,
-  album_id integer NOT NULL REFERENCES albums ON DELETE RESTRICT,
+  song_id integer NOT NULL,
+  artist_id integer NOT NULL,
+  album_id integer NOT NULL,
   song_name text NOT NULL,
   song_data_url text NOT NULL,
   song_duration integer NOT NULL,
@@ -29,17 +29,29 @@ CREATE TABLE songs (
 );
 
 CREATE TABLE users (
-  user_id integer PRIMARY KEY,
+  user_id integer NOT NULL,
   username text NOT NULL
 );
 
 CREATE TABLE song_comments (
-  comment_id integer PRIMARY KEY,
-  song_id integer NOT NULL REFERENCES songs ON DELETE CASCADE,
-  user_id integer NOT NULL REFERENCES users ON DELETE CASCADE,
+  comment_id integer NOT NULL,
+  song_id integer NOT NULL,
+  user_id integer NOT NULL,
   comment text NOT NULL,
   second_in_song integer,
   date_posted timestamp with time zone NOT NULL
 );
+
+-- after seeding db
+ALTER TABLE artists ADD PRIMARY KEY (artist_id);
+ALTER TABLE albums ADD PRIMARY KEY (album_id);
+ALTER TABLE songs ADD PRIMARY KEY (song_id);
+ALTER TABLE users ADD PRIMARY KEY (user_id);
+ALTER TABLE song_comments ADD PRIMARY KEY (comment_id);
+
+ALTER TABLE songs ADD FOREIGN KEY (artist_id) REFERENCES artists ON DELETE RESTRICT;
+ALTER TABLE songs ADD FOREIGN KEY (album_id) REFERENCES albums ON DELETE RESTRICT;
+ALTER TABLE song_comments ADD FOREIGN KEY (song_id) REFERENCES songs ON DELETE CASCADE;
+ALTER TABLE song_comments ADD FOREIGN KEY (user_id) REFERENCES users ON DELETE CASCADE;
 
 CREATE INDEX song_ids ON song_comments (song_id);


### PR DESCRIPTION
- remove PK and FK constraints from table definitions, add alter table commands & index at the end instead
- update comments data generation (70million records, assigning a random song id with a bias towards the 8millionth id)

Db seeding time for comments table: 5mins
Number of comments per song: mostly low numbers, but up to 47

<img width="242" alt="Screen Shot 2019-11-08 at 12 47 32 AM" src="https://user-images.githubusercontent.com/10113718/68462437-6307e880-01c1-11ea-904b-95e90a0f0629.png">
<img width="252" alt="Screen Shot 2019-11-08 at 12 47 20 AM" src="https://user-images.githubusercontent.com/10113718/68462444-669b6f80-01c1-11ea-802b-aad61933b988.png">

