### PR TITLE
Cache with redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ db/data
 newrelic.js
 newrelic_agent.log
 public/bundle.js
+dump.rdb
 
 # Configuration files
 config.js

--- a/Server/index.js
+++ b/Server/index.js
@@ -56,7 +56,7 @@ app.get('/songs/:songid', (req, res) => {
     .catch((err) => {
       if (responseSent) return;
       console.log(err);
-      res.end();
+      res.status(500).end()
     })
 });
 

--- a/Server/index.js
+++ b/Server/index.js
@@ -56,7 +56,7 @@ app.get('/songs/:songid', (req, res) => {
     .catch((err) => {
       if (responseSent) return;
       console.log(err);
-      res.status(500).end()
+      res.status(500).end();
     })
 });
 

--- a/http_get.js
+++ b/http_get.js
@@ -2,12 +2,18 @@ import http from "k6/http";
 const SONG_MAX_COUNT = 10000000; // 10 million
 
 export let options = {
-  vus: 240,
-  duration: "45s"
+  vus: 200,
+  duration: "1m"
 };
 
+function getRndBias(min, max, bias, influence) {
+  var rnd = Math.random() * (max - min) + min; // random in range
+  var mix = Math.random() * influence; // random mixer
+  return Math.round(rnd * (1 - mix) + bias * mix); // mix full range and bias
+}
+
 export default function() {
-  var songId = Math.floor(Math.random() * SONG_MAX_COUNT) + 1; // pick random song
+  var songId = getRndBias(1, SONG_MAX_COUNT, SONG_MAX_COUNT * 0.8, 0.95);
   http.get(`http://localhost:5001/songs/${songId}`);
 };
 

--- a/http_get.js
+++ b/http_get.js
@@ -3,7 +3,8 @@ const SONG_MAX_COUNT = 10000000; // 10 million
 
 export let options = {
   vus: 200,
-  duration: "1m"
+  rps: 1200,
+  duration: "5m"
 };
 
 function getRndBias(min, max, bias, influence) {
@@ -13,34 +14,7 @@ function getRndBias(min, max, bias, influence) {
 }
 
 export default function() {
-  var songId = getRndBias(1, SONG_MAX_COUNT, SONG_MAX_COUNT * 0.8, 0.95);
+  // var songId = getRndBias(1, SONG_MAX_COUNT, SONG_MAX_COUNT * 0.8, 0.95);
+  var songId = Math.floor(Math.random() * (SONG_MAX_COUNT - (9999000) + 1)) + 9999000;
   http.get(`http://localhost:5001/songs/${songId}`);
 };
-
-// import { sleep } from "k6";
-// import http from "k6/http";
-// const SONG_MAX_COUNT = 10000000; // 10 million
-
-// var desiredRPS = 950;
-// var RPSperVU = 4;
-// var VUsRequired = Math.round(desiredRPS / RPSperVU);
-
-// export let options = {
-//   vus: VUsRequired,
-//   duration: '15s',
-// };
-
-// export default function() {
-//   var iterationStart = new Date().getTime(); // timestamp in ms
-//   var songId = Math.floor(Math.random() * SONG_MAX_COUNT) + 1; // pick random song
-
-//   for (let i of Array(RPSperVU).keys()) {
-//     http.get(`http://localhost:5001/songs/${songId}`);
-//   }
-
-//   var iterationDuration = (new Date().getTime() - iterationStart) / 1000;
-//   var sleepTime = 1 - iterationDuration;
-//   if (sleepTime > 0) {
-//     sleep(sleepTime);
-//   }
-// }

--- a/http_post.js
+++ b/http_post.js
@@ -4,11 +4,12 @@ var ARTIST_MAX_COUNT = 1000000; // 1 million
 
 export let options = {
   vus: 200,
+  // rps: 1200,
   duration: "30s"
 };
 
 var randomNumber = function(min, max) {
-  return Math.floor(Math.random() * (max - min + 1)) + min;;
+  return Math.floor(Math.random() * (max - min + 1)) + min;
 };
 
 export default function() {
@@ -31,52 +32,3 @@ export default function() {
   var params =  { headers: { "Content-Type": "application/json" } }
   http.post(url, payload, params);
 };
-
-// import { sleep } from "k6";
-// import http from "k6/http";
-// var ALBUM_MAX_COUNT = 1000000; // 1 million
-// var ARTIST_MAX_COUNT = 1000000; // 1 million
-
-// var desiredRPS = 1000;
-// var RPSperVU = 4;
-// var VUsRequired = Math.round(desiredRPS / RPSperVU);
-
-// export let options = {
-//   vus: VUsRequired,
-//   duration: '30s',
-// };
-
-// var randomNumber = function(min, max) {
-//   return Math.floor(Math.random() * (max - min + 1)) + min;;
-// };
-
-// export default function() {
-//   var iterationStart = new Date().getTime(); // timestamp in ms
-
-//   for (let i of Array(RPSperVU).keys()) {
-//     var url = 'http://localhost:5001/songs';
-//     var tags = ['# Electronic', '# Rock', '# Alternative', '# Rap', '# Classical', '# Country', '# Jazz', '# Pop', '# Punk'];
-//     var song = {
-//       artistId: randomNumber(1, ARTIST_MAX_COUNT),
-//       albumId: randomNumber(1, ALBUM_MAX_COUNT),
-//       songName: 'test song name',
-//       songDataUrl: 'test song url',
-//       songDuration: randomNumber(100, 300),
-//       songWaveform: {
-//           "positiveValues": '[0.17,0.21,0.07,0.16,0.14,0.24,0.04,0.26,0.13,0.42,0.27]'
-//       },
-//       tag: tags[randomNumber(0, tags.length - 1)],
-//       datePosted: '2018-11-08T15:00:00'
-//     };
-  
-//     var payload = JSON.stringify(song);
-//     var params =  { headers: { "Content-Type": "application/json" } }
-//     http.post(url, payload, params);
-//   }
-
-//   var iterationDuration = (new Date().getTime() - iterationStart) / 1000;
-//   var sleepTime = 1 - iterationDuration;
-//   if (sleepTime > 0) {
-//     sleep(sleepTime);
-//   }
-// }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4964,6 +4964,11 @@
         "is-obj": "^1.0.0"
       }
     },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
     "download": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
@@ -10623,6 +10628,26 @@
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
       }
+    },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
+      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
     "reflect.ownkeys": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "pg-copy-streams": "^2.2.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
+    "redis": "^2.8.0",
     "stream-handbook": "^1.0.0",
     "style-loader": "^1.0.0",
     "zlib": "^1.0.5"


### PR DESCRIPTION
- install & promisify redis
- gitignore redis store
- update GET /songs/:songid endpoint to check cache when req received, and respond with data in cache or query db and save result to cache
- add bias to songs picked for stress testing (makes it more likely same song picked again, and cache can be used)

Querying the last 1k records only, the avg req duration drops from 188ms without redis to 25ms. Over 5mins with 200vus and ~1krps
<img width="1270" alt="Screen Shot 2019-11-11 at 6 04 24 PM" src="https://user-images.githubusercontent.com/10113718/68635621-01d86180-04ae-11ea-9b04-a28b824a02d9.png">
